### PR TITLE
Fixing an error in dev-test.yaml.

### DIFF
--- a/hiera/data/env/dev-test.yaml
+++ b/hiera/data/env/dev-test.yaml
@@ -38,7 +38,6 @@ rjil::base::self_signed_cert: true
 
 rjil::system::apt::enable_puppetlabs: false
 
-rjil::ceph::osd::autodetect: false
 rjil::ceph::osd::osd_journal_size: 10
 rjil::ceph::mon::pool_pg_num: 32
 


### PR DESCRIPTION
Since there were multiple entries of autodetect, puppet was considering autodetect as false and there was no way to detect the ceph disks on the node. Removed the extra false entry of autodetect.